### PR TITLE
Add Recover Metabolism feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Clearing the user's inventory
 - Resetting a user's blueprints
 - Resetting a user's metabolism (Identical to how a respawn sets a random metabolism)
+- Recover a user's metabolism (Gives the user a healthy metabolic state by filling their hunger, thirst, oxygen, and removing bleeding and radiation.)
 - Hurting a user
 - Healing a user
 - The ability to see a user's vitals, status and steamID64
@@ -27,6 +28,7 @@
 - **playeradministration.clearinventory** -- Allows the user to clear any player's inventory
 - **playeradministration.resetblueprint** -- Allows the user to reset any player's blueprints
 - **playeradministration.resetmetabolism** -- Allows the user to reset any player's metabolism
+- **playeradministration.recovermetabolism** -- Allows the user to give any player a healthy metabolic state
 - **playeradministration.hurt** -- Allows the user to hurt any player
 - **playeradministration.heal** -- Allows the user to heal any player
 - **playeradministration.voicemute** -- Allows the user to mute the voice chat of any player

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The default messages are in the `PlayerAdministration.json` file under the `oxid
   "Clear Inventory Button Text": "Clear Inventory",
   "Reset Blueprints Button Text": "Reset Blueprints",
   "Reset Metabolism Button Text": "Reset Metabolism",
+  "Recover Metabolism Button Text": "Recover Metabolism",
 
   "Hurt 25 Button Text": "Hurt 25",
   "Hurt 50 Button Text": "Hurt 50",


### PR DESCRIPTION
One feature this plugin has been missing is the option to "recover" or set the player to a healthy metabolic state.

This feature adds a new button, "Recover Metabolism", which does precisely that. It sets the hunger, thirst, oxygen, radiation, poison, comfort, etc. levels to an optimal or healthy.

More specifically:
```C#
playerState.bleeding.value = playerState.bleeding.min;
playerState.calories.value = playerState.calories.max;
playerState.comfort.value = 0;
playerState.hydration.value = playerState.hydration.max;
playerState.oxygen.value = playerState.oxygen.max;
playerState.poison.value = playerState.poison.min;
playerState.radiation_level.value = playerState.radiation_level.min;
playerState.radiation_poison.value = playerState.radiation_poison.min;
playerState.temperature.value = (PlayerMetabolism.HotThreshold + PlayerMetabolism.ColdThreshold) / 2;
playerState.wetness.value = playerState.wetness.min;
```