### PR TITLE
Add missing label and clarity for when plugins aren't installed

### DIFF
--- a/PlayerAdministration.cs
+++ b/PlayerAdministration.cs
@@ -1101,12 +1101,15 @@ namespace Oxide.Plugins
                                  GetMessage("Kill Button Text", aUiUserId));
             }
 
-            if (PermissionsManager != null && VerifyPermission(aUiUserId, CPermPerms)) {
+            if (PermissionsManager == null) {
+                aUIObj.AddButton(aParent, CUserPageBtnPermsLbAnchor, CUserPageBtnPermsRtAnchor, CuiDefaultColors.ButtonInactive, CuiDefaultColors.Text,
+                                 GetMessage("Perms Not Installed Button Text", aUiUserId));
+            } else if (VerifyPermission(aUiUserId, CPermPerms)) {
                 aUIObj.AddButton(aParent, CUserPageBtnPermsLbAnchor, CUserPageBtnPermsRtAnchor, CuiDefaultColors.ButtonSuccess, CuiDefaultColors.TextAlt,
                                  GetMessage("Perms Button Text", aUiUserId), $"{CPermsCmd} {aPlayerId}");
             } else {
                 aUIObj.AddButton(aParent, CUserPageBtnPermsLbAnchor, CUserPageBtnPermsRtAnchor, CuiDefaultColors.ButtonInactive, CuiDefaultColors.Text,
-                                 GetMessage("Perms Not Installed Button Text", aUiUserId));
+                                 GetMessage("Perms Button Text", aUiUserId));
             }
         }
 
@@ -1171,7 +1174,10 @@ namespace Oxide.Plugins
         /// <param name="aPlayer">Player who's information we need to display</param>
         private void AddUserPageThirdActionRow(ref Cui aUIObj, string aParent, string aUiUserId, ulong aPlayerId, ref BasePlayer aPlayer)
         {
-            if (Freeze != null && VerifyPermission(aUiUserId, CPermFreeze) && aPlayer.IsConnected) {
+            if (Freeze == null) {
+                aUIObj.AddButton(aParent, CUserPageBtnFreezeLbAnchor, CUserPageBtnFreezeRtAnchor, CuiDefaultColors.ButtonInactive, CuiDefaultColors.Text,
+                            GetMessage("Freeze Not Installed Button Text", aUiUserId));
+            } else if (VerifyPermission(aUiUserId, CPermFreeze) && aPlayer.IsConnected) {
                 if (GetIsFrozen(aPlayerId)) {
                     aUIObj.AddButton(aParent, CUserPageBtnFreezeLbAnchor, CUserPageBtnFreezeRtAnchor, CuiDefaultColors.ButtonInactive, CuiDefaultColors.Text,
                                 GetMessage("Freeze Button Text", aUiUserId));
@@ -1758,7 +1764,9 @@ namespace Oxide.Plugins
                 { "Unban Button Text", "Unban" },
 
                 { "Perms Button Text", "Permissions" },
+                { "Perms Not Installed Button Text", "Perms Not Installed" },
                 { "Freeze Button Text", "Freeze" },
+                { "Freeze Not Installed Button Text", "Freeze Not Installed" },
                 { "UnFreeze Button Text", "UnFreeze" },
 
                 { "Voice Mute Button Text", "Mute Voice" },

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ The default messages are in the `PlayerAdministration.json` file under the `oxid
   "Unban Button Text": "Unban",
 
   "Perms Button Text": "Permissions",
+  "Perms Not Installed Button Text": "Perms Not Installed",
   "Freeze Button Text": "Freeze",
+  "Freeze Not Installed Button Text": "Freeze Not Installed",
   "UnFreeze Button Text": "UnFreeze",
 
   "Voice Mute Button Text": "Mute Voice",


### PR DESCRIPTION
This adds the "Perms Not Installed Button Text" label that was previously missing.

Furthermore, I've added separate conditionals (and necessary labels) to differentiate between not having the necessary permissions and not having a plugin isn't installed.

![image](https://user-images.githubusercontent.com/8495484/48007050-c9f14e00-e0e4-11e8-8324-55157cd77b86.png)