### PR TITLE
Use `viewbackpack` chat command to open backpacks

### DIFF
--- a/PlayerAdministration.cs
+++ b/PlayerAdministration.cs
@@ -3207,7 +3207,7 @@ namespace Oxide.Plugins
             if (!VerifyPermission(ref player, CPermBackpacks, true) || !GetTargetFromArg(aArgs, out targetId))
                 return;
 
-            Backpacks.Call("ViewBackpack", player, string.Empty, new[] { targetId.ToString() });
+            player.SendConsoleCommand($"chat.say \"/viewbackpack {targetId}\"");
             LogInfo($"{player.displayName}: Viewed backpack of {targetId}");
             PlayerAdministrationCloseUICallback(player.IPlayer, string.Empty, new[] { string.Empty });
         }


### PR DESCRIPTION
In the upcoming Backpacks versions, v3.9 and v3.10, the `ViewBackpack` command has been renamed, and now accepts an `IPlayer`, not a `BasePlayer`. Player Administration should never have been calling the `ViewBackpack` method directly, since it was not documented as a public API. Using the chat command will work for current and upcoming versions of Backpacks.

For context:
- https://umod.org/community/backpacks/46314-backpacks-beta-390
- https://umod.org/community/backpacks/46426-backpacks-beta-3100
- https://umod.org/community/player-administration/46516-support-for-backpacks-beta